### PR TITLE
add player and DmgType to weapon hits

### DIFF
--- a/Pandaros.Settlers/Pandaros.Settlers/Items/ItemFactory.cs
+++ b/Pandaros.Settlers/Pandaros.Settlers/Items/ItemFactory.cs
@@ -106,7 +106,7 @@ namespace Pandaros.Settlers.Items
                 }
                 else if (NPCTracker.TryGetNPC(rayCastHit.hitNPCID, out var nPCBase))
                 {
-                    nPCBase.OnHit(WeaponLookup[click.typeSelected].Damage);
+                    nPCBase.OnHit(WeaponLookup[click.typeSelected].Damage, player, ModLoader.OnHitData.EHitSourceType.PlayerClick);
                     state.Weapon.Durability--;
                     ServerManager.SendAudio(nPCBase.Position.Vector, "punch");
                 }


### PR DESCRIPTION
npc.OnHit is tracked by ColonyCommandsMod and potentially other mods to detect players killing another player's NPC. The OnHit call with damage value only makes the hit unidentifiable where it is coming from. Adding the player as source of the hit and the damage type fixes this.