### PR TITLE
change slab placement for compatibility with antigrief mods

### DIFF
--- a/Pandaros.Settlers/Pandaros.Settlers/GameLoader.cs
+++ b/Pandaros.Settlers/Pandaros.Settlers/GameLoader.cs
@@ -269,10 +269,7 @@ namespace Pandaros.Settlers
 
                     if (ItemTypes.IndexLookup.TryGetIndex(otherTypename, out var otherIndex))
                     {
-                        var position = userData.Position;
-
-                        ThreadManager
-                           .InvokeOnMainThread(delegate { ServerManager.TryChangeBlock(position, otherIndex); }, 0.1f);
+                        userData.TypeNew = otherIndex;
                     }
                 }
             }

--- a/Pandaros.Settlers/Pandaros.Settlers/Textures/texturemapping.json
+++ b/Pandaros.Settlers/Pandaros.Settlers/Textures/texturemapping.json
@@ -1061,37 +1061,37 @@
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/berrybush.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslabbottom": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslabtop": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslableft": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslabright": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslabfront": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"
   },
   "Pandaros.Settlers.AutoLoad.stonebrickslabback": {
-    "albedo": "gamedata/textures/materials/blocks/albedo/leavesTaiga.png",
+    "albedo": "gamedata/textures/materials/blocks/albedo/stoneBricks.png",
     "normal": "gamedata/textures/materials/blocks/normal/neutral.png",
     "emissive": "gamedata/textures/materials/blocks/emissiveMaskAlpha/neutral.png",
     "height": "gamedata/textures/materials/blocks/heightSmoothnessSpecularity/neutral.png"

--- a/Pandaros.Settlers/Pandaros.Settlers/types.json
+++ b/Pandaros.Settlers/Pandaros.Settlers/types.json
@@ -2963,28 +2963,34 @@
       "useHeightMap": true
     }
   },
-  "marbleslableft": {
+  "Pandaros.Settlers.AutoLoad.marbleslableft": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slableft.obj"
   },
   "Pandaros.Settlers.AutoLoad.marbleslabright": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slabright.obj"
   },
   "Pandaros.Settlers.AutoLoad.marbleslabfront": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slabfront.obj"
   },
   "Pandaros.Settlers.AutoLoad.marbleslabback": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slabback.obj"
   },
   "Pandaros.Settlers.AutoLoad.marbleslabbottom": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slabbottom.obj"
   },
   "Pandaros.Settlers.AutoLoad.marbleslabtop": {
     "parentType": "Pandaros.Settlers.AutoLoad.marbleslab",
+    "sideall": "SELF",
     "mesh": "./Meshes/slabtop.obj"
   },
   "Pandaros.Settlers.AutoLoad.rawmarbleslab": {


### PR DESCRIPTION
Placement of slabs uses an explicit call to ServerManager.TryChangeBlock
If an AntiGrief mod is installed and its OnTryChangeBlock callback is called after the one of the Settlers Mod the AntiGrief mod can no longer cancel the block change event (or rather, canceling the event has no effect)
With the current base game version the explicit call to ServerManager.TryChangeBlock is not needed, it is enough to update the block type to the desired type, thereby keeping all activity within the original change event 