### PR TITLE
Berry pie/pancake "infinite" production fix

### DIFF
--- a/Pandaros.Settlers/Pandaros.Settlers/AutoLoad/baking.json
+++ b/Pandaros.Settlers/Pandaros.Settlers/AutoLoad/baking.json
@@ -42,6 +42,7 @@
         "amount": 2
       },
       {
+        "isOptional": true,
         "type": "bucketempty"
       }
     ],
@@ -76,6 +77,7 @@
         "amount": 2
       },
       {
+        "isOptional": true,
         "type": "bucketempty"
       }
     ],


### PR DESCRIPTION
Pies and pancakes were producing way above the set limit due to emptybucket not being optional (the game was trying to use those recipes to fill orders for the buckets, and since most buckets are water buckets they would get into an infinite loop of making those recipes).